### PR TITLE
Fix missing link in HTML doc and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,12 @@
 a morphological analyzer using [MeCab](https://en.wikipedia.org/wiki/MeCab)
 dictionary, written in Rust.
 
+Additional doc can be found at [https://hexdocs.pm/exawabi](https://hexdocs.pm/exawabi).
+
 ## Requirements
 
-MeCab https://taku910.github.io/mecab/ and related dictionary is required.
+- [MeCab](https://taku910.github.io/mecab/) and related dictionary.
+- [Rust](https://www.rust-lang.org/tools/install) for compiling Rust's Natively Implemented Function (NIF) binding.
 
 ### Debian/Ubuntu
 ```
@@ -31,7 +34,3 @@ def deps do
   ]
 end
 ```
-
-And need to install [Rust](https://www.rust-lang.org/tools/install) on compile NIF.
-
-The docs can be found at [https://hexdocs.pm/exawabi](https://hexdocs.pm/exawabi).

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,7 @@
 defmodule ExAwabi.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/nakagami/exawabi"
   @version "0.1.2"
 
   def project do
@@ -35,15 +36,15 @@ defmodule ExAwabi.MixProject do
     [
       maintainers: ["Hajime Nakagami"],
       licenses: ["MIT"],
-      links: %{"GitHub" => "https://github.com/nakagami/exawabi"},
+      links: %{"GitHub" => @source_url},
       files: ["lib", "native", "mix.exs", "README*", "LICENSE*"]
     ]
   end
 
   defp docs() do
     [
-      source_ref: "v#{@version}",
       main: "ExAwabi",
+      source_url: @source_url,
       extras: ["README.md"]
     ]
   end


### PR DESCRIPTION
This PR fixes the missing link to source code in generated HTML doc and update the instruction in README file.