### PR TITLE
Fix NIF linking on Apple Silicon macOS

### DIFF
--- a/native/awabi_nif/.cargo/config.toml
+++ b/native/awabi_nif/.cargo/config.toml
@@ -3,3 +3,9 @@ rustflags = [
     "-C", "link-arg=-undefined",
     "-C", "link-arg=dynamic_lookup",
 ]
+
+[target.aarch64-apple-darwin]
+rustflags = [
+    "-C", "link-arg=-undefined",
+    "-C", "link-arg=dynamic_lookup",
+]


### PR DESCRIPTION
Adds the same macOS dynamic lookup linker flags for aarch64-apple-darwin that already exist for x86_64-apple-darwin.

Without this, compiling the Rust NIF on Apple Silicon fails with unresolved _enif_* symbols because those symbols are provided by the Erlang VM when the NIF is loaded.